### PR TITLE
Port to Varnish6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ Makefile.in
 
 /src/vcc_if.c
 /src/vcc_if.h
+/src/vmod_statsd.man.rst
+/src/vmod_statsd.rst
+/vmod_statsd.3

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,18 +1,26 @@
-ACLOCAL_AMFLAGS = -I m4
+ACLOCAL_AMFLAGS = -I m4 -I ${LIBVARNISHAPI_DATAROOTDIR}/aclocal
 
 SUBDIRS = src
 
-EXTRA_DIST = README.rst
+DISTCHECK_CONFIGURE_FLAGS = \
+	VMOD_DIR='$${libdir}/varnish/vmods'
+
+EXTRA_DIST = README.rst LICENSE vmod-statsd.spec debian
+
+doc_DATA = README.rst LICENSE
 
 dist_man_MANS = vmod_statsd.3
 MAINTAINERCLEANFILES = $(dist_man_MANS)
 
 vmod_statsd.3: README.rst
+
+%.1 %.2 %.3 %.4 %.5 %.6 %.7 %.8 %.9:
 if HAVE_RST2MAN
-	${RST2MAN} README.rst $@
+	${RST2MAN} $< $@
 else
 	@echo "========================================"
 	@echo "You need rst2man installed to make dist"
 	@echo "========================================"
 	@false
 endif
+

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,9 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-Varnish Module (vmod) for sending statistics to Statsd.
+Varnish 4.x Module (vmod) for sending statistics to Statsd.
+
+See https://github.com/jib/libvmod-statsd/tree/master for Varnish 3.x version.
 
 See https://github.com/etsy/statsd for documentation on Statsd.
 
@@ -190,11 +192,7 @@ Usage::
  ./autogen.sh
 
  # Execute configure script
- ./configure VARNISHSRC=DIR [VMODDIR=DIR]
-
-`VARNISHSRC` is the directory of the Varnish source tree for which to
-compile your vmod. Both the `VARNISHSRC` and `VARNISHSRC/include`
-will be added to the include search paths for your module.
+ ./configure
 
 Optionally you can also set the vmod install directory by adding
 `VMODDIR=DIR` (defaults to the pkg-config discovered directory from your

--- a/autogen.sh
+++ b/autogen.sh
@@ -35,9 +35,18 @@ else
 	esac
 fi
 
+# check for varnishapi.m4 in custom paths
+dataroot=$(pkg-config --variable=datarootdir varnishapi 2>/dev/null)
+if [ -z "$dataroot" ] ; then
+	cat >&2 <<'EOF'
+Package varnishapi was not found in the pkg-config search path.
+Perhaps you should add the directory containing `varnishapi.pc'
+to the PKG_CONFIG_PATH environment variable
+EOF
+	exit 1
+fi
 set -ex
-
-aclocal -I m4
+aclocal -I m4 -I ${dataroot}/aclocal
 $LIBTOOLIZE --copy --force
 autoheader
 automake --add-missing --copy --foreign

--- a/configure.ac
+++ b/configure.ac
@@ -29,43 +29,17 @@ if test "x$RST2MAN" = "xno"; then
 fi
 AM_CONDITIONAL(HAVE_RST2MAN, [test "x$RST2MAN" != "xno"])
 
-# Check for pkg-config
-PKG_PROG_PKG_CONFIG
-
 # Checks for header files.
 AC_HEADER_STDC
 AC_CHECK_HEADERS([sys/stdlib.h])
 
-# Check for python
-AC_CHECK_PROGS(PYTHON, [python3 python3.1 python3.2 python2.7 python2.6 python2.5 python2 python], [AC_MSG_ERROR([Python is needed to build this vmod, please install python.])])
+# Varnish include files tree
+VARNISH_VMOD_INCLUDES
+VARNISH_VMOD_DIR
+VARNISH_VMODTOOL
 
-# Varnish source tree
-AC_ARG_VAR([VARNISHSRC], [path to Varnish source tree (mandatory)])
-if test "x$VARNISHSRC" = x; then
-	AC_MSG_ERROR([No Varnish source tree specified])
-fi
-VARNISHSRC=`cd $VARNISHSRC && pwd`
-AC_CHECK_FILE([$VARNISHSRC/include/varnishapi.h],
-	[],
-	[AC_MSG_FAILURE(["$VARNISHSRC" is not a Varnish source directory])]
-)
-AM_CONDITIONAL(HAVE_VARNISHSRC, [test -n $VARNISHSRC])
-
-# Check that varnishtest is built in the varnish source directory
-AC_CHECK_FILE([$VARNISHSRC/bin/varnishtest/varnishtest],
-	[],
-	[AC_MSG_FAILURE([Can't find "$VARNISHSRC/bin/varnishtest/varnishtest". Please build your varnish source directory])]
-)
-
-# vmod installation dir
-AC_ARG_VAR([VMODDIR], [vmod installation directory @<:@LIBDIR/varnish/vmods@:>@])
-if test "x$VMODDIR" = x; then
-	VMODDIR=`pkg-config --variable=vmoddir varnishapi`
-	if test "x$VMODDIR" = x; then
-		AC_MSG_FAILURE([Can't determine vmod installation directory])
-	fi
-fi
-AM_CONDITIONAL(HAVE_VMODDIR, [test -n $VMODDIR])
+AC_PATH_PROG([VARNISHTEST], [varnishtest])
+AC_PATH_PROG([VARNISHD], [varnishd])
 
 AC_CONFIG_FILES([
 	Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
 AC_PREREQ(2.59)
-AC_COPYRIGHT([Copyright (c) 2011 Varnish Software AS])
+AC_COPYRIGHT([Copyright (c) 2011-2015 Varnish Software AS])
 AC_INIT([libvmod-statsd], [trunk])
 AC_CONFIG_MACRO_DIR([m4])
-m4_ifndef([VARNISH_VMOD_INCLUDES], AC_MSG_ERROR([Need varnish.m4]))
+m4_ifndef([VARNISH_VMOD_INCLUDES], AC_MSG_ERROR([Need varnish.m4 -- see README.rst]))
 AC_CONFIG_SRCDIR(src/vmod_statsd.vcc)
 AM_CONFIG_HEADER(config.h)
 
@@ -67,7 +67,6 @@ AC_PATH_PROG([VARNISHTEST], [varnishtest], [],
     [$LIBVARNISHAPI_BINDIR:$LIBVARNISHAPI_SBINDIR:$PATH])
 AC_PATH_PROG([VARNISHD], [varnishd], [],
     [$LIBVARNISHAPI_SBINDIR:$LIBVARNISHAPI_BINDIR:$PATH])
-
 
 AC_CONFIG_FILES([
 	Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,7 @@ AC_PREREQ(2.59)
 AC_COPYRIGHT([Copyright (c) 2011 Varnish Software AS])
 AC_INIT([libvmod-statsd], [trunk])
 AC_CONFIG_MACRO_DIR([m4])
+m4_ifndef([VARNISH_VMOD_INCLUDES], AC_MSG_ERROR([Need varnish.m4]))
 AC_CONFIG_SRCDIR(src/vmod_statsd.vcc)
 AM_CONFIG_HEADER(config.h)
 
@@ -33,13 +34,40 @@ AM_CONDITIONAL(HAVE_RST2MAN, [test "x$RST2MAN" != "xno"])
 AC_HEADER_STDC
 AC_CHECK_HEADERS([sys/stdlib.h])
 
+# backwards compat with older pkg-config
+# - pull in AC_DEFUN from pkg.m4
+m4_ifndef([PKG_CHECK_VAR], [
+# PKG_CHECK_VAR(VARIABLE, MODULE, CONFIG-VARIABLE,
+# [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+# -------------------------------------------
+# Retrieves the value of the pkg-config variable for the given module.
+AC_DEFUN([PKG_CHECK_VAR],
+[AC_REQUIRE([PKG_PROG_PKG_CONFIG])dnl
+AC_ARG_VAR([$1], [value of $3 for $2, overriding pkg-config])dnl
+
+_PKG_CONFIG([$1], [variable="][$3]["], [$2])
+AS_VAR_COPY([$1], [pkg_cv_][$1])
+
+AS_VAR_IF([$1], [""], [$5], [$4])dnl
+])# PKG_CHECK_VAR
+])
+
+PKG_CHECK_MODULES([libvarnishapi], [varnishapi])
+PKG_CHECK_VAR([LIBVARNISHAPI_DATAROOTDIR], [varnishapi], [datarootdir])
+PKG_CHECK_VAR([LIBVARNISHAPI_BINDIR], [varnishapi], [bindir])
+PKG_CHECK_VAR([LIBVARNISHAPI_SBINDIR], [varnishapi], [sbindir])
+AC_SUBST([LIBVARNISHAPI_DATAROOTDIR])
+
 # Varnish include files tree
 VARNISH_VMOD_INCLUDES
 VARNISH_VMOD_DIR
 VARNISH_VMODTOOL
 
-AC_PATH_PROG([VARNISHTEST], [varnishtest])
-AC_PATH_PROG([VARNISHD], [varnishd])
+AC_PATH_PROG([VARNISHTEST], [varnishtest], [],
+    [$LIBVARNISHAPI_BINDIR:$LIBVARNISHAPI_SBINDIR:$PATH])
+AC_PATH_PROG([VARNISHD], [varnishd], [],
+    [$LIBVARNISHAPI_SBINDIR:$LIBVARNISHAPI_BINDIR:$PATH])
+
 
 AC_CONFIG_FILES([
 	Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,4 +25,7 @@ EXTRA_DIST = \
 	vmod_statsd.vcc \
 	$(VMOD_TESTS)
 
-CLEANFILES = $(builddir)/vcc_if.c $(builddir)/vcc_if.h
+CLEANFILES = $(builddir)/vcc_if.c $(builddir)/vcc_if.h \
+	$(builddir)/vmod_statsd.man.rst \
+	$(builddir)/vmod_statsd.rst \
+	$(builddir)/../vmod_statsd.3

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,23 +1,6 @@
-# if VARNISHSRC is defined on the command-line, use that. Otherwise, build
-# this the same as the modules that come with varnish (i.e. we're building
-# within the varnish src dir itself, and $(top_srcdir) is the varnish source).
-#
-if HAVE_VARNISHSRC
-SRC = $(VARNISHSRC)
-DIR_PREFIX = /
-else
-SRC = $(top_srcdir)
-DIR_PREFIX = lib/libvmod-statsd/
-endif
+AM_CPPFLAGS = @VMOD_INCLUDES@
 
-INCLUDES = -I$(SRC)/include -I$(SRC)
-
-if HAVE_VMODDIR
-vmoddir = $(VMODDIR)
-else
-vmoddir = $(pkglibdir)/vmods
-endif
-
+vmoddir = @VMOD_DIR@
 vmod_LTLIBRARIES = libvmod_statsd.la
 
 libvmod_statsd_la_LDFLAGS = -module -export-dynamic -avoid-version
@@ -27,14 +10,14 @@ libvmod_statsd_la_SOURCES = \
 	vcc_if.h \
 	vmod_statsd.c
 
-vcc_if.c vcc_if.h: $(SRC)/lib/libvmod_std/vmod.py $(top_srcdir)/$(DIR_PREFIX)src/vmod_statsd.vcc
-	@PYTHON@ $(SRC)/lib/libvmod_std/vmod.py $(top_srcdir)/$(DIR_PREFIX)src/vmod_statsd.vcc
+vcc_if.c vcc_if.h: @VMODTOOL@ $(top_srcdir)/$(DIR_PREFIX)src/vmod_statsd.vcc
+	@VMODTOOL@ $(top_srcdir)/$(DIR_PREFIX)src/vmod_statsd.vcc
 
 VMOD_TESTS = tests/*.vtc
 .PHONY: $(VMOD_TESTS)
 
 tests/*.vtc:
-	$(SRC)/bin/varnishtest/varnishtest -Dvarnishd=$(SRC)/bin/varnishd/varnishd -Dvmod_topbuild=$(abs_top_builddir) $@
+	@VARNISHTEST@ -Dvarnishd=@VARNISHD@ -Dvmod_topbuild=$(abs_top_builddir) $@
 
 check: $(VMOD_TESTS)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,10 +13,10 @@ libvmod_statsd_la_SOURCES = \
 vcc_if.c vcc_if.h: @VMODTOOL@ $(top_srcdir)/$(DIR_PREFIX)src/vmod_statsd.vcc
 	@VMODTOOL@ $(top_srcdir)/$(DIR_PREFIX)src/vmod_statsd.vcc
 
-VMOD_TESTS = tests/*.vtc
+VMOD_TESTS = $(top_srcdir)/src/tests/*.vtc
 .PHONY: $(VMOD_TESTS)
 
-tests/*.vtc:
+$(top_srcdir)/src/tests/*.vtc:
 	@VARNISHTEST@ -Dvarnishd=@VARNISHD@ -Dvmod_topbuild=$(abs_top_builddir) $@
 
 check: $(VMOD_TESTS)

--- a/src/tests/test02.vtc
+++ b/src/tests/test02.vtc
@@ -1,0 +1,46 @@
+varnishtest "Test sending stats"
+
+server s1 {
+       rxreq
+       txresp
+} -start
+
+# XXX I don't know how to test reception of UDP packets from varnish,
+# so for now, these tests just make sure that the process doesn't crash,
+# hang, or do anything else bad
+
+varnish v1 -vcl+backend {
+	import statsd from "${vmod_topbuild}/src/.libs/libvmod_statsd.so";
+
+    sub vcl_init {
+        statsd.server("localhost", "1");    # nothing listens on UDP port 1 right?
+        statsd.prefix("prefix");
+        statsd.suffix("suffix");
+    }
+
+    sub vcl_deliver {
+        statsd.incr(    "incr"          );
+        statsd.gauge(   "gauge",    1234567890  );
+        statsd.timing(  "timing",   1234567890  );
+        statsd.counter( "counter",  1234567890  );
+
+        # So we know we got to at least here.
+        set resp.http.hello = "Hello, World";
+    }
+
+} -start
+
+logexpect l1 -v v1 {
+  expect * * VCL_Log "vmod-statsd: Sent 20 of 20 bytes "
+  expect * * VCL_Log "Could not write stat 'prefixgaugesuffix:1234567890|g'"
+} -start
+
+client c1 {
+	txreq -url "/"
+	rxresp
+	expect resp.http.hello == "Hello, World"
+}
+
+client c1 -run
+
+logexpect l1 -wait

--- a/src/vmod_statsd.c
+++ b/src/vmod_statsd.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "vcl.h"
 #include "vrt.h"
 #include "cache/cache.h"
 
@@ -80,7 +81,7 @@ free_function(void *priv) {
 }
 
 int
-init_function(struct vmod_priv *priv, const struct VCL_conf *conf) {
+init_function(const struct vrt_ctx *ctx, struct vmod_priv *priv, enum vcl_event_e e) {
 
     // ******************************
     // Configuration defaults

--- a/src/vmod_statsd.c
+++ b/src/vmod_statsd.c
@@ -83,6 +83,9 @@ free_function(void *priv) {
 int
 init_function(const struct vrt_ctx *ctx, struct vmod_priv *priv, enum vcl_event_e e) {
 
+    if (e != VCL_EVENT_LOAD)
+        return (0);
+
     // ******************************
     // Configuration defaults
     // ******************************

--- a/src/vmod_statsd.c
+++ b/src/vmod_statsd.c
@@ -2,9 +2,18 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "vcl.h"
-#include "vrt.h"
-#include "cache/cache.h"
+#include <cache/cache.h>
+#include <vcl.h>
+
+#ifndef VRT_H_INCLUDED
+#include <vrt.h>
+#endif
+
+#ifndef VDEF_H_INCLUDED
+#include <vdef.h>
+#endif
+
+
 
 #include "vcc_if.h"
 

--- a/src/vmod_statsd.c
+++ b/src/vmod_statsd.c
@@ -3,7 +3,7 @@
 #include <string.h>
 
 #include "vrt.h"
-#include "bin/varnishd/cache.h"
+#include "cache/cache.h"
 
 #include "vcc_if.h"
 
@@ -107,23 +107,23 @@ init_function(struct vmod_priv *priv, const struct VCL_conf *conf) {
 }
 
 /** The following may ONLY be called from VCL_init **/
-void
-vmod_prefix( struct sess *sp, struct vmod_priv *priv, const char *prefix ) {
+VCL_VOID
+vmod_prefix( const struct vrt_ctx *ctx, struct vmod_priv *priv, const char *prefix ) {
     config_t *cfg = priv->priv;
     cfg->prefix = _strip_newline( strdup( prefix ) );
 }
 
 /** The following may ONLY be called from VCL_init **/
-void
-vmod_suffix( struct sess *sp, struct vmod_priv *priv, const char *suffix ) {
+VCL_VOID
+vmod_suffix( const struct vrt_ctx *ctx, struct vmod_priv *priv, const char *suffix ) {
 
     config_t *cfg = priv->priv;
     cfg->suffix = _strip_newline( strdup( suffix ) );
 }
 
 /** The following may ONLY be called from VCL_init **/
-void
-vmod_server( struct sess *sp, struct vmod_priv *priv, const char *host, const char *port ) {
+VCL_VOID
+vmod_server( const struct vrt_ctx *ctx, struct vmod_priv *priv, VCL_STRING host, VCL_STRING port ) {
 
     // ******************************
     // Configuration
@@ -326,16 +326,16 @@ _send_to_statsd( struct vmod_priv *priv, const char *key, const char *val ) {
 }
 
 
-void
-vmod_incr( struct sess *sp, struct vmod_priv *priv, const char *key ) {
+VCL_VOID
+vmod_incr( const struct vrt_ctx *ctx, struct vmod_priv *priv, VCL_STRING key ) {
     _DEBUG && fprintf( stderr, "vmod-statsd: incr: %s\n", key );
 
     // Incremenet is straight forward - just add the count + type
     _send_to_statsd( priv, key, ":1|c" );
 }
 
-void
-vmod_timing( struct sess *sp, struct vmod_priv *priv, const char *key, int num ) {
+VCL_VOID
+vmod_timing( const struct vrt_ctx *ctx, struct vmod_priv *priv, const char *key, VCL_INT num ) {
     _DEBUG && fprintf( stderr, "vmod-statsd: timing: %s = %d\n", key, num );
 
     // Get the buffer ready. 10 for the maximum lenghth of an int and +5 for metadata
@@ -347,8 +347,8 @@ vmod_timing( struct sess *sp, struct vmod_priv *priv, const char *key, int num )
     _send_to_statsd( priv, key, val );
 }
 
-void
-vmod_counter( struct sess *sp, struct vmod_priv *priv, const char *key, int num ) {
+VCL_VOID
+vmod_counter( const struct vrt_ctx *ctx, struct vmod_priv *priv, const char *key, VCL_INT num ) {
     _DEBUG && fprintf( stderr, "vmod-statsd: counter: %s = %d\n", key, num );
 
     // Get the buffer ready. 10 for the maximum lenghth of an int and +5 for metadata
@@ -360,8 +360,8 @@ vmod_counter( struct sess *sp, struct vmod_priv *priv, const char *key, int num 
     _send_to_statsd( priv, key, val );
 }
 
-void
-vmod_gauge( struct sess *sp, struct vmod_priv *priv, const char *key, int num ) {
+VCL_VOID
+vmod_gauge( const struct vrt_ctx *ctx, struct vmod_priv *priv, const char *key, VCL_INT num ) {
     _DEBUG && fprintf( stderr, "vmod-statsd: gauge: %s = %d\n", key, num );
 
     // Get the buffer ready. 10 for the maximum lenghth of an int and +5 for metadata
@@ -372,28 +372,4 @@ vmod_gauge( struct sess *sp, struct vmod_priv *priv, const char *key, int num ) 
 
     _send_to_statsd( priv, key, val );
 }
-
-
-// const char *
-// vmod_hello(struct sess *sp, const char *name)
-// {
-// 	char *p;
-// 	unsigned u, v;
-//
-// 	u = WS_Reserve(sp->wrk->ws, 0); /* Reserve some work space */
-// 	p = sp->wrk->ws->f;		/* Front of workspace area */
-// 	v = snprintf(p, u, "Hello, %s", name);
-// 	v++;
-// 	if (v > u) {
-// 		/* No space, reset and leave */
-// 		WS_Release(sp->wrk->ws, 0);
-// 		return (NULL);
-// 	}
-// 	/* Update work space with what we've used */
-// 	WS_Release(sp->wrk->ws, v);
-// 	return (p);
-// }
-
-//     _DEBUG && fprintf( stderr, "vmod-statsd: Open: %.9f Req: %.9f Res: %.9f End: %.9f\n",
-//         sp->t_open, sp->t_req, sp->t_resp, sp->t_end );
 

--- a/src/vmod_statsd.vcc
+++ b/src/vmod_statsd.vcc
@@ -1,5 +1,5 @@
 $Module statsd 3 StatsD Client
-$Init init_function
+$Event init_function
 $Function VOID server( PRIV_VCL, STRING, STRING )
 $Function VOID prefix( PRIV_VCL, STRING )
 $Function VOID suffix( PRIV_VCL, STRING )

--- a/src/vmod_statsd.vcc
+++ b/src/vmod_statsd.vcc
@@ -1,9 +1,9 @@
-Module statsd
-Init init_function
-Function VOID server( PRIV_VCL, STRING, STRING )
-Function VOID prefix( PRIV_VCL, STRING )
-Function VOID suffix( PRIV_VCL, STRING )
-Function VOID incr( PRIV_VCL, STRING )
-Function VOID gauge( PRIV_VCL, STRING, INT )
-Function VOID timing( PRIV_VCL, STRING, INT )
-Function VOID counter( PRIV_VCL, STRING, INT )
+$Module statsd 3 StatsD Client
+$Init init_function
+$Function VOID server( PRIV_VCL, STRING, STRING )
+$Function VOID prefix( PRIV_VCL, STRING )
+$Function VOID suffix( PRIV_VCL, STRING )
+$Function VOID incr( PRIV_VCL, STRING )
+$Function VOID gauge( PRIV_VCL, STRING, INT )
+$Function VOID timing( PRIV_VCL, STRING, INT )
+$Function VOID counter( PRIV_VCL, STRING, INT )

--- a/vmod-statsd.spec
+++ b/vmod-statsd.spec
@@ -1,0 +1,41 @@
+Summary: Varnish module for sending statistics to statsd.
+Name: vmod-statsd
+Version: 0.1
+Release: 1%{?dist}
+License: BSD
+Group: System Environment/Daemons
+Source0: libvmod-statsd.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+Requires: varnish >= 4.0.2
+BuildRequires: make
+BuildRequires: python-docutils
+BuildRequires: varnish >= 4.0.2
+BuildRequires: varnish-libs-devel >= 4.0.2
+
+%description
+Example VMOD
+
+%prep
+%setup -n libvmod-statsd-trunk
+
+%build
+%configure --prefix=/usr/
+%{__make} %{?_smp_mflags}
+%{__make} %{?_smp_mflags} check
+
+%install
+[ %{buildroot} != "/" ] && %{__rm} -rf %{buildroot}
+%{__make} install DESTDIR=%{buildroot}
+
+%clean
+[ %{buildroot} != "/" ] && %{__rm} -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%{_libdir}/varnis*/vmods/
+%doc /usr/share/doc/lib%{name}/*
+%{_mandir}/man?/*
+
+%changelog
+* Tue Nov 14 2012 Lasse Karstensen <lasse@varnish-software.com> - 0.1-0.20121114
+- Initial version.


### PR DESCRIPTION
based on #13  - and ported to be compilable against varnish6.0

also refactors the logging, and uses VSLog instead of `fprintf`  - and a second test, verifing the log entry's showing up - with `logexpect`